### PR TITLE
Add connect-mongo to store session data in our mongodb

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,22 +7,37 @@ var bodyParser = require('body-parser');
 const expressValidator = require('express-validator');
 const session = require('express-session');
 const passport = require('passport');
+const mongoose = require('mongoose');
+const MongoStore = require('connect-mongo')(session);
 
 var index = require('./routes/index');
 var users = require('./routes/users');
 
 var app = express();
 
+// mongoose setup
+mongoose.Promise = global.Promise;
+mongoose.connect('mongodb://localhost/project2');
+
+// create a persisent session store re-using our mongoose connection
+// It creates/uses a collection called "sessions" by default
+const sessionStore = new MongoStore({ mongooseConnection: mongoose.connection });
+
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
 app.use(express.static(__dirname));
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(cookieParser());
 
 // Express session
 // needed by Express Messages and Passport
 app.use(session({
   secret: 'secret',
   resave: false,
+  store: sessionStore,
   saveUninitialized: true
 }));
 
@@ -63,9 +78,6 @@ app.use(expressValidator({
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', index);
@@ -90,3 +102,4 @@ app.use(function(err, req, res, next) {
 });
 
 module.exports = app;
+module.exports.sessionStore = sessionStore;

--- a/models/user.js
+++ b/models/user.js
@@ -1,6 +1,4 @@
 const mongoose = require('mongoose');
-mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/project2');
 const bcrypt = require('bcryptjs');
 
 // User Schema

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-session": "*",
     "express-validator": "*",
     "connect-flash": "*",
+    "connect-mongo": "^1.3.2",
     "passport": "*",
     "passport-http": "*",
     "passport-local": "*",


### PR DESCRIPTION
Be sure to do a "npm install" after pulling this in.

By default express-session stores in memory the session data for
each user. It's not recommended for production, and more importantly
isn't compatible with passport.socket.io which we need (coming in next patch).

FYI it also means that user logins will survive nodejs restarts.

Now session data will be stored in the "session" collection in our
project2 mongodb as seen here:

$ mongo
MongoDB shell version: 3.2.8
connecting to: test
> use project2
switched to db project2
> show collections
sessions
users
> db.sessions.find().pretty()
{
        "_id" : "dp5RSMQxk0fjpw7ATA1BZ9bTzA4Xp8Hm",
        "session" : "{\"cookie\":{\"originalMaxAge\":null,\"expires\":null,\"httpOnly\":true,\"path\":\"/\"},\"flash\":{},\"passport\":{\"user\":\"58a3525728076d187ef21049\"}}",
        "expires" : ISODate("2017-03-08T07:45:09.633Z")
}
>

You'll notice that the passport object won't exist when the user is logged out.

To delete all session do:

> db.sessions.remove({})