### PR TITLE
Add passport.socketio

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -5,10 +5,13 @@
  */
 
 var app = require('../app');
+const sessionStore = require('../app').sessionStore;
+const passportSocketIo = require('passport.socketio');
 var debug = require('debug')('project2:server');
 var http = require('http');
 var socket = require('socket.io');
 var socketController = require('../routes/socket');
+const cookieParser = require('cookie-parser');
 
 /**
  * Get port from environment and store in Express.
@@ -23,6 +26,21 @@ app.set('port', port);
 
 var server = http.createServer(app);
 var io = socket(server);
+
+// wire up socket.io and passport
+// makes the socket.request.user object available inside of
+// io.on('connection', socket => {
+// the user object has the name and username properties of the
+// logged in user
+// also makes it so socket.io requests can only come from a
+// logged in session
+io.use(passportSocketIo.authorize({
+  cookieParser: cookieParser, // the same middleware you registrer in express
+  key: 'connect.sid',         // the name of the cookie where express/connect stores its session_id
+  secret: 'secret',           // the secret to parse the cookie, needs to match what express-session uses
+  store: sessionStore,        // requires a sessionstore, not a memorystore
+}));
+
 socketController(io);
 
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "passport": "*",
     "passport-http": "*",
     "passport-local": "*",
+    "passport.socketio": "^3.7.0",
     "bcryptjs": "*",
     "jquery": "*"
   }


### PR DESCRIPTION
Wire up socket.io and passport for two reasons:

1. Makes the socket.request.user object available inside of the
server side io.on('connection', socket => ... code

The user object has "name" and "username" properties of the
logged in user

Enables code like:

// server side
socket.on('getMyUserObject', (data, callback) => {
    socket.emit('user', socket.request.user);
});

// client side
let name = '';
let usernamename = '';

socket.emit('getMyUserObject');

socket.on('user', data => {
  name = data.name;
  username = data.username;
  console.log('got name: ' + name);
  console.log('got username: ' + username);
});

2. Also makes it so socket.io requests can only come from a
logged in session